### PR TITLE
🐛 キー情報は書き込み権限のあるものに変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,17 +98,18 @@ commands:
           path: ./doc
           destination: yard-results
 
-  # Deploy RubyGems
   deploy-rubygems:
     steps:
       # ref:https://support.circleci.com/hc/ja/articles/115015628247-%E6%8E%A5%E7%B6%9A%E3%82%92%E7%B6%9A%E8%A1%8C%E3%81%97%E3%81%BE%E3%81%99%E3%81%8B-%E3%81%AF%E3%81%84-%E3%81%84%E3%81%84%E3%81%88-
+      # read/write両方の権限が必要
       - add_ssh_keys:
           fingerprints:
-            - "7e:b2:fb:7e:f9:c0:35:b6:fd:c4:c0:dd:ac:b6:b0:23"
+            - "38:d2:72:5e:9f:67:93:9a:ec:95:94:a2:0e:bf:41:9e"
       - run:
           name: Deploy RubyGems
           command: |
-            curl -u dodonki1223:$RUBYGEMS_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials
+            curl -u dodonki1223:$RUBYGEMS_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
+            chmod 0600 ~/.gem/credentials
             git config user.name dodonki1223
             git config user.email $RUBYGEMS_EMAIL
             bundle exec rake build


### PR DESCRIPTION
## 下記対応でよいのだが書き込み権限がないといけなかった

- 書き込み権限ありの権限を作成する
    - [Circle CI で Github に write access 可能な Deploy key を設定する - Qiita](https://qiita.com/boushi-bird@github/items/6b6eb1d1ed6f6d3341e4)

### デプロイ中に下記出力になってデプロイが失敗する

<img width="983" alt="スクリーンショット 2020-02-22 21 03 42" src="https://user-images.githubusercontent.com/14287054/75092006-d5f16f80-55b6-11ea-84aa-c069457dad1c.png">

#### 原因

- sshで初回ログイン時に"The authenticity of host 'host' can't be established..."と聞かれてしまう
- CircleCIで対処法が乗っているのでそれに習って修正する
    - https://support.circleci.com/hc/ja/articles/115015628247-%E6%8E%A5%E7%B6%9A%E3%82%92%E7%B6%9A%E8%A1%8C%E3%81%97%E3%81%BE%E3%81%99%E3%81%8B-%E3%81%AF%E3%81%84-%E3%81%84%E3%81%84%E3%81%88-

### 修正方法

ここのドキュメントを参考に行った

- https://support.circleci.com/hc/ja/articles/115015628247-%E6%8E%A5%E7%B6%9A%E3%82%92%E7%B6%9A%E8%A1%8C%E3%81%97%E3%81%BE%E3%81%99%E3%81%8B-%E3%81%AF%E3%81%84-%E3%81%84%E3%81%84%E3%81%88-

### その他

一般的には下記の記事のように対応するみたい
- https://journal.lampetty.net/entry/wp/391