### PR TITLE
🔧 バージョン情報を詳細に記載する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     qiita_trend (0.3.9)
-      mechanize
+      mechanize (~> 2.7.6)
       nokogiri (>= 1.10.8)
 
 GEM
@@ -108,19 +108,19 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  pry
-  pry-byebug
-  pry-doc
+  pry (~> 0.13.1)
+  pry-byebug (~> 3.9.0)
+  pry-doc (~> 1.1.0)
   qiita_trend!
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter
   rubocop (~> 0.62)
-  rubocop-rspec
-  simplecov
-  vcr
-  webmock
-  yard
+  rubocop-rspec (~> 1.39.0)
+  simplecov (~> 0.18.5)
+  vcr (~> 5.1.0)
+  webmock (~> 3.8.3)
+  yard (~> 0.9.24)
 
 BUNDLED WITH
    2.1.2

--- a/qiita_trend.gemspec
+++ b/qiita_trend.gemspec
@@ -38,20 +38,20 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # qiita_trendに必要な依存gem設定（ここは最小限にすること）
-  spec.add_dependency 'mechanize'
+  spec.add_dependency 'mechanize', '~> 2.7.6'
   spec.add_dependency 'nokogiri', '>= 1.10.8'
   # 開発中のみ必要なgem設定
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'pry-doc'
+  spec.add_development_dependency 'pry', '~> 0.13.1'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
+  spec.add_development_dependency 'pry-doc', '~> 1.1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop', '~> 0.62'
-  spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.39.0'
+  spec.add_development_dependency 'simplecov', '~> 0.18.5'
+  spec.add_development_dependency 'vcr', '~> 5.1.0'
+  spec.add_development_dependency 'webmock', '~> 3.8.3'
+  spec.add_development_dependency 'yard', '~> 0.9.24'
 end


### PR DESCRIPTION
## 修正内容

- gemのバージョン情報を記載するのが推奨らしいのでちゃんと記載する
    - Gemfile.lockからバージョン情報を取ってきて設定する