### PR TITLE
🐛 月初に発生するバグの修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ executors:
           # Bundlerのパス設定が書き換えられ`vendor/bundle`ではなくて`/usr/local/bundle`を参照してしまい`bundle exec`でエラーになる
           # Bundlerのconfigファイル(pathの設定がされたもの)をworkspaceで永続化し`vendor/bundle`を参照するようにするための設定
           BUNDLE_APP_CONFIG: .bundle
+          # ref: https://circleci.com/docs/2.0/faq/#how-can-i-set-the-timezone-in-docker-images
+          TZ: "Asia/Tokyo"
     working_directory: ~/dodonki1223/qiita_trend
 
 commands:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /vendor/
+/test_results/
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.4.1)
+    qiita_trend (0.4.2)
       mechanize (~> 2.7)
-      nokogiri (>= 1.10)
+      nokogiri (~> 1.10)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/qiita_trend.gemspec
+++ b/qiita_trend.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   # qiita_trendに必要な依存gem設定（ここは最小限にすること）
   spec.add_dependency 'mechanize', '~> 2.7'
-  spec.add_dependency 'nokogiri', '>= 1.10'
+  spec.add_dependency 'nokogiri', '~> 1.10'
   # 開発中のみ必要なgem設定
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry', '~> 0.13'

--- a/spec/qiita_trend/target_spec.rb
+++ b/spec/qiita_trend/target_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe QiitaTrend::Target do
                       'https://qiita.com/'
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::DAILY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 12),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 12),
                       "#{Time.now.strftime('%Y%m%d')}05_#{QiitaTrend::TrendType::DAILY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::DAILY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 18),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 18),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::DAILY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::DAILY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day + 1, 4),
+                      Time.new(Date.today.year, Date.today.month, Date.today.next_day(1).day, 4),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::DAILY}.html"
     end
 
@@ -54,15 +54,15 @@ RSpec.describe QiitaTrend::Target do
                       'https://qiita.com/?scope=weekly'
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::WEEKLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 12),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 12),
                       "#{Time.now.strftime('%Y%m%d')}05_#{QiitaTrend::TrendType::WEEKLY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::WEEKLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 18),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 18),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::WEEKLY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::WEEKLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day + 1, 4),
+                      Time.new(Date.today.year, Date.today.month, Date.today.next_day(1).day, 4),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::WEEKLY}.html"
     end
 
@@ -75,15 +75,15 @@ RSpec.describe QiitaTrend::Target do
                       'https://qiita.com/?scope=monthly'
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::MONTHLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 12),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 12),
                       "#{Time.now.strftime('%Y%m%d')}05_#{QiitaTrend::TrendType::MONTHLY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::MONTHLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day, 18),
+                      Time.new(Date.today.year, Date.today.month, Date.today.day, 18),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::MONTHLY}.html"
       it_behaves_like 'cache name that matches the type and time',
                       QiitaTrend::TrendType::MONTHLY,
-                      Time.new(Time.now.year, Time.now.month, Time.now.day + 1, 4),
+                      Time.new(Date.today.year, Date.today.month, Date.today.next_day(1).day, 4),
                       "#{Time.now.strftime('%Y%m%d')}17_#{QiitaTrend::TrendType::MONTHLY}.html"
     end
   end


### PR DESCRIPTION
## 修正内容

- CircleCIで実行しているRSpecのコマンドを実行した時に作成されるファイルをGitの管理外にする
- 警告の出ていた nokogiri のバージョン指定を修正
- 月初に発生するバグの修正
    - ローカルとCircleCiでタイムゾーンの違いによりローカルで再現できなかったためCircleCIのタイムゾーンをローカルと合わせる
    - RSpec で月初の時だけ発生するバグの修正

## その他

- CircleCIでタイムゾーンの設定はこちらを参照すること
    - https://circleci.com/docs/2.0/faq/#how-can-i-set-the-timezone-in-docker-images

**タイムゾーンがUTCからJSTになっていることを確認**

![スクリーンショット 2020-09-01 9 17 56](https://user-images.githubusercontent.com/14287054/91780988-1996f700-ec34-11ea-9a37-5de7e1710c5a.png)
