### PR TITLE
🐛 Qiitaのトレンド情報の取得先の仕様変更対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.4.3)
+    qiita_trend (0.4.4)
       mechanize (~> 2.7)
       nokogiri (~> 1.10)
 

--- a/lib/qiita_trend/trend.rb
+++ b/lib/qiita_trend/trend.rb
@@ -20,8 +20,7 @@ module QiitaTrend
     def initialize(trend_type = TrendType::DAILY, date = nil)
       page = Page.new(trend_type, date)
       parsed_html = Nokogiri::HTML.parse(page.html)
-
-      trends_data = JSON.parse(parsed_html.xpath('//div[@data-hyperapp-app="Trend"]')[0]['data-hyperapp-props'])
+      trends_data = JSON.parse(parsed_html.xpath('//script[@data-component-name="HomeArticleTrendFeed"]')[0].text)
       @data = trends_data['trend']['edges']
     end
 

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end


### PR DESCRIPTION
# 修正内容

- Qiitaのトレンド情報の取得先のDOM構成が変わったためその対応

<img width="1775" alt="スクリーンショット 2020-10-07 7 02 51" src="https://user-images.githubusercontent.com/14287054/95264948-33e37680-086b-11eb-82eb-363d14e3f528.png">
