### PR TITLE
🔧 CircleCI の Docker Hub レート制限対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   base:
     docker:
-      - image: circleci/ruby:2.6.0
+      - image: cimg/ruby:2.6.6
         auth:
           username: dodonki1223
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ executors:
   base:
     docker:
       - image: circleci/ruby:2.6.0
+        auth:
+          username: dodonki1223
+          password: $DOCKERHUB_PASSWORD
         environment:
           # Bundlerのパス設定が書き換えられ`vendor/bundle`ではなくて`/usr/local/bundle`を参照してしまい`bundle exec`でエラーになる
           # Bundlerのconfigファイル(pathの設定がされたもの)をworkspaceで永続化し`vendor/bundle`を参照するようにするための設定


### PR DESCRIPTION
# 修正内容

## Docker Hub のレート制限対応

詳しい修正概要などは下記の記事を参考にすること

- [Docker Hubのレート制限に関するFAQ](https://support.circleci.com/hc/ja/articles/360050623311-Docker-Hub%E3%81%AE%E3%83%AC%E3%83%BC%E3%83%88%E5%88%B6%E9%99%90%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8BFAQ) 

実際の修正方法下記の記事を参考にすること

- [https://circleci.com/docs/2.0/private-images/](https://circleci.com/docs/2.0/private-images/)

### 対応方法

Docker の Image の箇所に Docker Hub にログインできる情報を設定した

```yml
auth:
  username: dodonki1223
  password: $DOCKERHUB_PASSWORD
```
### 対応後

#### 変更前（警告が出ている）

![スクリーンショット 2020-10-31 21 55 34](https://user-images.githubusercontent.com/14287054/97779822-0ff22700-1bc4-11eb-93a4-5efc91b1ea28.png)

#### 変更後（警告がでなくなる）

![スクリーンショット 2020-10-31 21 58 01](https://user-images.githubusercontent.com/14287054/97779907-960e6d80-1bc4-11eb-96dc-bd66c8a6c59d.png)

プロジェクトの環境変数に **DOCKERHUB_PASSWORD** を設定

### 迷ったところ

- Organization全体で使用できる環境変数（context）があったが、** executors**  では使用できないようだ
- jobs には context を使用することができる
- 個人プロジェクトでは関係ない設定だが覚えておくと良さそう

## CircleCIで使用していた Image を次世代のものに変更

- circleci/ruby:2.6.0 から cimg/ruby:2.6.6 に変更
- [cimg/ruby](https://circleci.com/developer/images/image/cimg/ruby) についてはこちらを参照