### PR TITLE
♻️ CircleCI に ruby Orbs を導入する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,28 +31,8 @@ commands:
           # working_directory からの相対パスか絶対パスを指定します
           at: .
 
-  run-tests:
-    steps:
-      - run:
-          name: Run tests
-          command: |
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
-            bundle exec rspec \
-              --format progress \
-              --format RspecJunitFormatter \
-              --out test_results/rspec/rspec.xml \
-              --format progress \
-              $TEST_FILES
-
   collect-reports:
     steps:
-      # ref:https://circleci.com/docs/ja/2.0/configuration-reference/#store_test_results
-      - store_test_results:
-          path: test_results
-      - store_artifacts:
-          # テスト結果をtest-resultsディレクトリに吐き出す
-          path: test_results
-          destination: test-results
       - store_artifacts:
           # カバレッジの結果をcoverage-resultsディレクトリに吐き出す
           path: coverage
@@ -122,7 +102,8 @@ jobs:
     steps:
       - using-workspace
       - ruby/install-deps
-      - run-tests
+      - ruby/rspec-test:
+          out-path: 'test_results/rspec/'
       - collect-reports
 
   document:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  ruby: circleci/ruby@1.1.2
   slack: circleci/slack@3.4.2
 executors:
   base:
@@ -17,36 +18,6 @@ executors:
     working_directory: ~/dodonki1223/qiita_trend
 
 commands:
-  install-bundler:
-    steps:
-      - run:
-          name: Install bundler(2.1.0)
-          command: gem install bundler:2.1.0
-
-  # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-  restore-gem-cache:
-    steps:
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-  install-gem:
-    steps:
-      - run:
-          name: Install gem
-          command: |
-            # jobs=4は並列処理をして高速化するための設定（４つのjobで実行するって意味）
-            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
-
-  save-gem-cache:
-    steps:
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
   save-workspace:
     steps:
       - persist_to_workspace:
@@ -143,24 +114,21 @@ jobs:
     executor: base
     steps:
       - checkout
-      - install-bundler
-      - restore-gem-cache
-      - install-gem
-      - save-gem-cache
+      - ruby/install-deps
       - save-workspace
 
   lint:
     executor: base
     steps:
       - using-workspace
-      - install-bundler
+      - ruby/install-deps
       - run-rubocop
 
   test:
     executor: base
     steps:
       - using-workspace
-      - install-bundler
+      - ruby/install-deps
       - run-tests
       - collect-reports
 
@@ -168,14 +136,14 @@ jobs:
     executor: base
     steps:
       - using-workspace
-      - install-bundler
+      - ruby/install-deps
       - create-document
 
   deploy:
     executor: base
     steps:
       - using-workspace
-      - install-bundler
+      - ruby/install-deps
       - deploy-rubygems
       - deploy-notification
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,6 @@ commands:
           # working_directory からの相対パスか絶対パスを指定します
           at: .
 
-  run-rubocop:
-    steps:
-      - run:
-          name: Run RuboCop
-          command: |
-            bundle exec rubocop
-
   run-tests:
     steps:
       - run:
@@ -122,7 +115,7 @@ jobs:
     steps:
       - using-workspace
       - ruby/install-deps
-      - run-rubocop
+      - ruby/rubocop-check
 
   test:
     executor: base

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.4.4)
+    qiita_trend (0.4.5)
       mechanize (~> 2.7)
       nokogiri (~> 1.10)
 

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.4.4'
+  VERSION = '0.4.5'
 end


### PR DESCRIPTION
## 修正内容

- [circleci/ruby](https://circleci.com/developer/orbs/orb/circleci/ruby) の Orbs の導入
- Orbs の導入による必要のなくなった記述を削除
    - rubocop, RSpec のコマンドを定義していた箇所を削除
    - テスト結果のアップロード処理も Orbs に寄せる