### PR TITLE
🐛 json のキー名が createdAt から publishedAt の対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.4.5)
+    qiita_trend (0.4.6)
       mechanize (~> 2.7)
       nokogiri (~> 1.10)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ ruby -r qiita_trend -e "pp QiitaTrend::Trend.new.items"
    "https://qiita-image-store.s3.amazonaws.com/0/15319/profile-images/1473684249",
   "user_page"=>"https://qiita.com/akameco",
   "article"=>"https://qiita.com/akameco/items/e12377e55e379d29636e",
-  "created_at"=>"2019-08-05T01:17:34Z",
+  "published_at"=>"2019-08-05T01:17:34Z",
   "likes_count"=>158,
   "is_new_arrival"=>false},
  {"title"=>"Excelで誰でも簡単言語処理 (感情推定, 固有表現抽出, キーワード抽出,  文類似度推定 etc...)",
@@ -47,7 +47,7 @@ $ ruby -r qiita_trend -e "pp QiitaTrend::Trend.new.items"
   "user_image"=>"https://avatars2.githubusercontent.com/u/19549989?v=4",
   "user_page"=>"https://qiita.com/Harusugi",
   "article"=>"https://qiita.com/Harusugi/items/535874c0456dbc4db231",
-  "created_at"=>"2019-08-04T23:01:22Z",
+  "published_at"=>"2019-08-04T23:01:22Z",
   "likes_count"=>103,
   "is_new_arrival"=>false},
   ...
@@ -173,7 +173,7 @@ irb(main):001:0> pp QiitaTrend::Trend.new.items[0]
   "https://qiita-image-store.s3.amazonaws.com/0/15319/profile-images/1473684249",
  "user_page"=>"https://qiita.com/akameco",
  "article"=>"https://qiita.com/akameco/items/e12377e55e379d29636e",
- "created_at"=>"2019-08-05T01:17:34Z",
+ "published_at"=>"2019-08-05T01:17:34Z",
  "likes_count"=>158,
  "is_new_arrival"=>false}
 ```
@@ -213,7 +213,7 @@ irb(main):001:0> pp QiitaTrend::Trend.new.items[0]
       <td></td>
     </tr>
     <tr>
-      <td>created_at</td>
+      <td>published_at</td>
       <td>記事作成日</td>
       <td></td>
     </tr>

--- a/lib/qiita_trend/trend.rb
+++ b/lib/qiita_trend/trend.rb
@@ -35,7 +35,7 @@ module QiitaTrend
         result['user_image'] = user_image(trend['node']['author']['profileImageUrl'])
         result['user_page'] = "#{Page::QIITA_URI}#{trend['node']['author']['urlName']}"
         result['article'] = "#{Page::QIITA_URI}#{trend['node']['author']['urlName']}/items/#{trend['node']['uuid']}"
-        result['created_at'] = trend['node']['createdAt']
+        result['published_at'] = trend['node']['publishedAt']
         result['likes_count'] = trend['node']['likesCount']
         result['is_new_arrival'] = trend['isNewArrival']
         value << result

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end

--- a/spec/qiita_trend/trend_spec.rb
+++ b/spec/qiita_trend/trend_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe QiitaTrend::Trend do
 
   describe '#initialize' do
     let(:first_element) { trend.data[0] }
+    let(:node_keys) { %w[author title uuid createdAt likesCount] }
+    let(:author_keys) { %w[urlName profileImageUrl] }
 
     it 'TrendのデータがArrayであること' do
       expect(trend.data).to be_a Array
@@ -20,12 +22,26 @@ RSpec.describe QiitaTrend::Trend do
     it 'DataにisNewArrival,nodeのキーが存在すること' do
       expect(first_element).to include('isNewArrival', 'node')
     end
+
+    it 'nodeの配下にスクレイピング対象のキーが存在すること' do
+      node_keys.each { |key| expect(first_element['node'].keys).to include(key) }
+    end
+
+    it 'authorの配下にスクレイピング対象のキーが存在すること' do
+      author_keys.each { |key| expect(first_element['node']['author'].keys).to include(key) }
+    end
   end
 
   describe '#items' do
     subject(:first_items) { trend.items[0] }
 
+    let(:item_keys) { first_items.keys }
+
     it { is_expected.to include('title', 'user_name', 'user_image', 'likes_count', 'is_new_arrival', 'article', 'created_at', 'user_page') }
+
+    it 'すべての値が取得できていること' do
+      item_keys.each { |key| expect(first_items[key]).not_to eq nil }
+    end
   end
 
   describe '#new_items' do

--- a/spec/qiita_trend/trend_spec.rb
+++ b/spec/qiita_trend/trend_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe QiitaTrend::Trend do
 
   describe '#initialize' do
     let(:first_element) { trend.data[0] }
-    let(:node_keys) { %w[author title uuid createdAt likesCount] }
+    let(:node_keys) { %w[author title uuid publishedAt likesCount] }
     let(:author_keys) { %w[urlName profileImageUrl] }
 
     it 'TrendのデータがArrayであること' do
@@ -37,7 +37,7 @@ RSpec.describe QiitaTrend::Trend do
 
     let(:item_keys) { first_items.keys }
 
-    it { is_expected.to include('title', 'user_name', 'user_image', 'likes_count', 'is_new_arrival', 'article', 'created_at', 'user_page') }
+    it { is_expected.to include('title', 'user_name', 'user_image', 'likes_count', 'is_new_arrival', 'article', 'published_at', 'user_page') }
 
     it 'すべての値が取得できていること' do
       item_keys.each { |key| expect(first_items[key]).not_to eq nil }


### PR DESCRIPTION
## 概要

- json のキー名が createdAt から publishedAt に変更されていた

## 修正内容

- publishedAt に対応できるように修正
- キー名が変わったことが検知できなかったのでテストを追加
    - キー名のチェック
    - 取得したキーの値が nil で無いことのチェック（nil でないということは取得できた）