### PR TITLE
🐛  Qiitaの仕様変更によりトレンドが取得できなくなっていたバグの修正

### DIFF
--- a/lib/qiita_trend/trend.rb
+++ b/lib/qiita_trend/trend.rb
@@ -20,7 +20,7 @@ module QiitaTrend
     def initialize(trend_type = TrendType::DAILY, date = nil)
       page = Page.new(trend_type, date)
       parsed_html = Nokogiri::HTML.parse(page.html)
-      trends_data = JSON.parse(parsed_html.xpath('//script[@data-component-name="HomeArticleTrendFeed"]')[0].text)
+      trends_data = JSON.parse(parsed_html.xpath('//script[@data-component-name="NewHomeArticleTrendFeed"]')[0].text)
       @data = trends_data['trend']['edges']
     end
 


### PR DESCRIPTION
## トレンドが取得できなくなってしまったことについて

Qiitaの仕様変更により、json を取得する時の xpath が変更されていた

- https://blog.qiita.com/feed-update-202103/

## 修正内容

xpath 名を変更

## 今後の対応として

- Monthly と Weekly が廃止されたのでそのコードを削除する
- ログイン後に取得できるホームフィードを取得できるようにする