### PR TITLE
⭐️ Qiita トップページのアップデート対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.5.0)
+    qiita_trend (0.5.1)
       mechanize (~> 2.7)
       nokogiri (~> 1.11)
 

--- a/lib/qiita_trend/trend.rb
+++ b/lib/qiita_trend/trend.rb
@@ -22,7 +22,7 @@ module QiitaTrend
       @trend_type = trend_type
       page = Page.new(trend_type, date)
       parsed_html = Nokogiri::HTML.parse(page.html)
-      xpath_str = "//script[@data-component-name=\"#{data_component_name(trend_type)}\"]"
+      xpath_str = '//script[@data-component-name="HomeIndexPage"]'
       trends_data = JSON.parse(parsed_html.xpath(xpath_str)[0].text)
       @data = get_data(trends_data, trend_type)
     end
@@ -59,21 +59,13 @@ module QiitaTrend
 
     private
 
-    # QiitaのトレンドのFeed名を取得する
-    #
-    # @param [TrendType] trend_type トレンドタイプ
-    # @return [String] トレンドタイプによるFeed名
-    def data_component_name(trend_type)
-      trend_type == TrendType::PERSONAL ? 'HomeIndexPage' : 'HomeArticleTrendFeed'
-    end
-
     # Qiitaのトレンドのデータを取得する
     #
     # @param [Hash] trends_data トレンドデータ
     # @param [TrendType] trend_type トレンドタイプ
     # @return [Array] トレンドタイプによるトレンドデータ
     def get_data(trends_data, trend_type)
-      trend_type == TrendType::PERSONAL ? trends_data['personalizedFeed']['personalizedFeed']['edges'] : trends_data['trend']['edges']
+      trend_type == TrendType::PERSONAL ? trends_data['personalizedFeed']['personalizedFeed']['edges'] : trends_data['trend']['trend']['edges']
     end
 
     # ユーザーの画像のURLを取得する

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
# トップページの変更対応

Qiita ブログにかかれていますが、2021年12月20日にトップページのアップデートをリリースしたようです。
その変更で dom の構成が変わったのでそれに対応させます！

[ヘッダー＆トップページアップデート正式リリースのお知らせ](https://blog.qiita.com/qiita-header-and-toppage-update/)

> リリースは2021年12月20日を予定しています。

## 毎日実行しているテスト

CircleCI で毎日テストを実行していたおかげで dom の構成が違うことに気づくことができました！
ありがとう CircleCI！

https://app.circleci.com/pipelines/github/dodonki1223/qiita_trend/759/workflows/cc446a9a-3d83-423f-9f93-47d8714c58c5/jobs/1664