### PR TITLE
Personal トレンドと Normal トレンドの取得先の xpath の変更対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiita_trend (0.5.1)
+    qiita_trend (0.5.2)
       mechanize (~> 2.7)
       nokogiri (~> 1.11)
 

--- a/lib/qiita_trend/trend.rb
+++ b/lib/qiita_trend/trend.rb
@@ -22,7 +22,7 @@ module QiitaTrend
       @trend_type = trend_type
       page = Page.new(trend_type, date)
       parsed_html = Nokogiri::HTML.parse(page.html)
-      xpath_str = '//script[@data-component-name="HomeIndexPage"]'
+      xpath_str = get_xpath(trend_type)
       trends_data = JSON.parse(parsed_html.xpath(xpath_str)[0].text)
       @data = get_data(trends_data, trend_type)
     end
@@ -58,6 +58,14 @@ module QiitaTrend
     end
 
     private
+
+    # Qiitaのトレンド情報を格納しているxpathを取得する
+    #
+    # @param [TrendType] trend_type トレンドタイプ
+    # @return [String] トレンドタイプによるxpath
+    def get_xpath(trend_type)
+      trend_type == TrendType::PERSONAL ? '//script[@data-component-name="New2HomeIndexPage"]' : '//script[@data-component-name="HomeIndexPage"]'
+    end
 
     # Qiitaのトレンドのデータを取得する
     #

--- a/lib/qiita_trend/version.rb
+++ b/lib/qiita_trend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaTrend
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
Personal トレンドのデータの取得先の名前が「New2HomeIndexPage」に変わっていたため、これに対応する

![スクリーンショット 2022-09-14 8 24 22](https://user-images.githubusercontent.com/14287054/190026579-e9413498-9124-451a-9863-922f698dbbec.png)