### PR TITLE
🔧  CI が落ちるため nokogiri を arm64-darwin をやめる

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    nokogiri (1.13.9-arm64-darwin)
+    nokogiri (1.13.9)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)


### PR DESCRIPTION
前回の修正で gemfile が変わったことにより CI が落ちるようになったため、一旦何も考えずに修正する